### PR TITLE
fix: correct config path

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bin/gitit -f .gitit.conf
+web: bin/gitit -f gitit.conf


### PR DESCRIPTION
currently, deploying on heroku fails:

``` bash
2015-11-28T03:12:03.617995+00:00 heroku[web.1]: Starting process with command `bin/gitit -f .gitit.conf`
2015-11-28T03:12:05.905371+00:00 app[web.1]: -----> Configuring Gitit wiki
2015-11-28T03:12:05.899584+00:00 app[web.1]: -----> Configuring Gitit
2015-11-28T03:12:07.979023+00:00 app[web.1]:        Cloning git@github.com:<user>/<repo>... done, 226dc14
2015-11-28T03:12:07.983729+00:00 app[web.1]: -----> Gitit configured
2015-11-28T03:12:07.979983+00:00 app[web.1]: -----> Configuring Gitit wiki hooks
2015-11-28T03:12:07.987355+00:00 app[web.1]: gitit: .gitit.conf: openFile: does not exist (No such file or directory)
2015-11-28T03:12:08.691081+00:00 heroku[web.1]: Process exited with status 1
2015-11-28T03:12:08.698294+00:00 heroku[web.1]: State changed from starting to crashed
```
